### PR TITLE
Prevent pages from being registered by crawlers

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,15 @@
 import { AppProps } from 'next/app'
+import Head from 'next/head'
 
 import '../assets/app.css'
 
-const App = ({ Component, pageProps }: AppProps) => <Component {...pageProps} />
+const App = ({ Component, pageProps }: AppProps) => (
+  <>
+    <Head>
+      <meta name="robots" content="noindex, nofollow" />
+    </Head>
+    <Component {...pageProps} />
+  </>
+)
 
 export default App


### PR DESCRIPTION
`<head>`に`noindex`属性と`nofollow`属性を追加しました。
これでScrapbox Readerのページが検索結果に上がることはなくなるはずです。
既にindexされてしまったページは消せませんが……